### PR TITLE
Potential fix for code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/certilizer/__init__.py
+++ b/certilizer/__init__.py
@@ -33,6 +33,7 @@ def run(
 
     logger = init()
     context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
 
     logger.info(f"Loading configuration file {conf_file}...")
     cfgrw = CFGRW(conf_file=conf_file)


### PR DESCRIPTION
Potential fix for [https://github.com/cliffano/certilizer/security/code-scanning/1](https://github.com/cliffano/certilizer/security/code-scanning/1)

To fix the problem, we should explicitly restrict the SSL/TLS protocol to TLS 1.2 or higher. This is accomplished by setting the `minimum_version` property of the `SSLContext` object to `ssl.TLSVersion.TLSv1_2` immediately after its creation at line 35. This should be done in the `run` function, right after the existing call to `ssl.create_default_context()`. If the target environment is Python < 3.7, you may instead use flags (`options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1`), but for modern code (Python 3.7+), setting `minimum_version` is preferred. The change will be a single additional line assigning the desired minimum version, making the code robust against insecure protocols regardless of interpreter defaults.

No new imports are required, as `ssl.TLSVersion` is already available via the existing import.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
